### PR TITLE
Protect `getEventMetadataVersion`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colony/colony-event-metadata-parser",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@colony/colony-event-metadata-parser",
-      "version": "1.0.2",
+      "version": "1.0.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "lint-staged": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-event-metadata-parser",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "module": "./dist/esm/index.js",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/src/metadataParser.ts
+++ b/src/metadataParser.ts
@@ -33,7 +33,8 @@ const parseEventMetadata = (res: string): Metadata | undefined => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (validationError: any) {
     log.verbose('Metadata validation schema error:', validationError.message);
-    log.verbose('Res: ', validationError.value);
+    log.verbose('Error:', validationError);
+    log.verbose('Res: ', res);
     return undefined;
   }
 
@@ -139,6 +140,13 @@ export const getColonyAvatarImage = (res: string): string | undefined => {
   );
 };
 
-export function getEventMetadataVersion(response: string): number {
-  return (JSON.parse(response)?.version as number) || 1;
-}
+// @NOTE this rountine is protected with an Error if undefined
+// or falsy is passed in. Call this func in a try/catch block.
+export const getEventMetadataVersion = (
+  ipfsResponse: string,
+): number | never => {
+  if (typeof ipfsResponse === 'undefined' || !ipfsResponse) {
+    throw Error(`Cannot obtain metadata version from: ${ipfsResponse}`);
+  }
+  return (JSON.parse(ipfsResponse)?.version as number) || 1;
+};


### PR DESCRIPTION
This PR adds protection to `getEventMetadataVersion` for invalid param values. An error is thrown if an unexpected value is encountered.
Should call `getEventMetadataVersion` in a try/catch block.